### PR TITLE
Make Wikidata importing optional

### DIFF
--- a/language.sql
+++ b/language.sql
@@ -118,6 +118,7 @@ END;
 $$ STRICT
 LANGUAGE plpgsql IMMUTABLE;
 
+CREATE TABLE IF NOT EXISTS wd_names(id varchar(20), page varchar(200), labels hstore);
 
 CREATE OR REPLACE FUNCTION merge_wiki_names(tags hstore) RETURNS hstore AS $$
 DECLARE


### PR DESCRIPTION
@jirik @MartinMikita 

Based on text in  https://github.com/openmaptiles/openmaptiles/pull/358, importing Wikidata should be optional, this PR try to achieve this goal.

For now, if user doesn't run script like `docker-compose run --rm import-wikidata`
docker-compose service `import-sql` always fails at https://github.com/openmaptiles/import-sql/blob/f9a84094179b585889bc9a86d45cddc726925fd6/language.sql#L122-L135 because table for WIkidata doesn't exist.

The newly added line just create table if it doesn't exitst, it also fix this issue about Wikidata https://github.com/openmaptiles/openmaptiles/issues/454
If this PR is accepted, I'll add description of Wikidata in READEME for both using it or not  (for now it is 0...), and upgrade docker image version in `docker-compost.yml`
