### PR TITLE
Do not fail if there are no matching sql files in dir

### DIFF
--- a/import_sql.sh
+++ b/import_sql.sh
@@ -2,6 +2,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+shopt -s nullglob
 
 function exec_psql_file() {
     local file_name="$1"


### PR DESCRIPTION
if `*.sql` doesn't find any files, the for loop should not be even entered.

P.S. Unrelated to this patch, I'm not sure why there is a break statement
after the first import - shouldn't it import all of them?